### PR TITLE
Missing namespace declaration in IOAuth2GrantClient

### DIFF
--- a/lib/OAuth2/IOAuth2GrantClient.php
+++ b/lib/OAuth2/IOAuth2GrantClient.php
@@ -2,6 +2,8 @@
 
 namespace OAuth2;
 
+use OAuth2\Model\IOAuth2Client;
+
 /**
  * Storage engines that support the "Client Credentials"
  * grant type should implement this interface


### PR DESCRIPTION
A missing namespace declaration in IOAuth2GrantClient make it impossible to implement. This commit fix that.
