### PR TITLE
Update checkScope scope to enable overriding possibilities due to space ...

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -610,7 +610,7 @@ class OAuth2 {
    *
    * @ingroup oauth2_section_7
    */
-  private function checkScope($required_scope, $available_scope) {
+  protected function checkScope($required_scope, $available_scope) {
     // The required scope should match or be a subset of the available scope
     if (!is_array($required_scope)) {
       $required_scope = explode(' ', trim($required_scope));


### PR DESCRIPTION
...norm.

Like Facebook or Github, commas are more convenient characters to separe scopes and less difficult to encode.

Updating checkScope scope allow developers to handle themself scopes.
