### PR TITLE
Remove charset from the response content-type

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -1250,7 +1250,7 @@ class OAuth2 {
    */
   private function getJsonHeaders() {
     return array(
-      'Content-Type' => 'application/json;charset=UTF-8',
+      'Content-Type' => 'application/json',
       'Cache-Control' => 'no-store',
       'Pragma' => 'no-cache',
     );

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -358,7 +358,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase {
     )));
 
     $this->assertSame(array(
-      'content-type' => array('application/json;charset=UTF-8'),
+      'content-type' => array('application/json'),
       'cache-control' => array('no-store, private'),
       'pragma' => array('no-cache'),
     ), array_diff_key(
@@ -423,7 +423,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase {
     )));
 
     $this->assertSame(array(
-      'content-type' => array('application/json;charset=UTF-8'),
+      'content-type' => array('application/json'),
       'cache-control' => array('no-store, private'),
       'pragma' => array('no-cache'),
     ), array_diff_key(
@@ -457,7 +457,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase {
     )));
 
     $this->assertSame(array(
-      'content-type' => array('application/json;charset=UTF-8'),
+      'content-type' => array('application/json'),
       'cache-control' => array('no-store, private'),
       'pragma' => array('no-cache'),
     ), array_diff_key(
@@ -516,7 +516,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase {
     )));
 
     $this->assertSame(array(
-      'content-type' => array('application/json;charset=UTF-8'),
+      'content-type' => array('application/json'),
       'cache-control' => array('no-store, private'),
       'pragma' => array('no-cache'),
     ), array_diff_key(


### PR DESCRIPTION
The charset definition is not required as JSON use UTF-8 by default.
http://stackoverflow.com/a/14955491/450789

This is consistent with `OAuth2ServerException`.
https://github.com/FriendsOfSymfony/oauth2-php/blob/master/lib/OAuth2/OAuth2ServerException.php#L76
