### PR TITLE
Honor request's scope value

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -723,7 +723,12 @@ class OAuth2 {
       throw new OAuth2ServerException(self::HTTP_BAD_REQUEST, self::ERROR_INVALID_SCOPE, 'An unsupported scope was requested.');
     }
 
-    $token = $this->createAccessToken($client, $stored['data'], $stored['scope']);
+    // grant all possible scopes if the request doesn't pass in a scope value.
+    if (!$input['scope']) {
+        $input['scope'] = $stored['scope'];
+    }
+
+    $token = $this->createAccessToken($client, $stored['data'], $input['scope']);
 
     return new Response(json_encode($token), 200, $this->getJsonHeaders());
   }


### PR DESCRIPTION
In the OAuth2 spec on granting an access token, "the authorization server MAY fully or partially ignore the scope requested by the client based on the authorization server policy or the resource owner's instructions".

So OAuth2 spec doesn't have an opinion on how scope is being handled. But oauth2-php currently has an opinion: fully ignores the request's scope value. 

As a result, there is at least one use case that's impossible:
1. a client with a 'client_credentials' grant type  has both 'read' and 'write' scope.
2. the client wants to get an access token that can ONLY 'read' data.

With this PR, the client can ask for an access token of 'read' scope by passing in 'scope=read' in the request.
