### PR TITLE
Prevent alert when /dev/urandom is not accessible

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -1187,7 +1187,7 @@ class OAuth2 {
    * @see OAuth2::genAuthCode()
    */
   protected function genAccessToken() {
-    if (file_exists('/dev/urandom')) { // Get 100 bytes of random data
+    if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
       $randomData = file_get_contents('/dev/urandom', false, null, 0, 100);
     } elseif (function_exists('openssl_random_pseudo_bytes')) { // Get 100 bytes of pseudo-random data
       $bytes = openssl_random_pseudo_bytes(100, $strong);


### PR DESCRIPTION
Exception:

> Warning: file_exists() [<a href='function.file-exists'>function.file-exists</a>]: open_basedir restriction in effect. File(/dev/urandom) is not within the allowed path(s): (/usr/lib/php:/usr/local/lib/php:/tmp) in /.../vendor/friendsofsymfony/oauth2-php/lib/OAuth2/OAuth2.php line 1190
