### PR TITLE
Fixed supported scopes handling when grant_type is client_credentials

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -713,10 +713,10 @@ class OAuth2 {
     }
 
     if (!is_array($stored)) {
-      $stored = array();
+      $stored = array('scope' => $this->getVariable(self::CONFIG_SUPPORTED_SCOPES, null));
     }
 
-    $stored += array('scope' => NULL, 'data' => NULL);
+    $stored += array('scope' => null, 'data' => null);
 
     // Check scope, if provided
     if ($input["scope"] && (!isset($stored["scope"]) || !$this->checkScope($input["scope"], $stored["scope"]))) {


### PR DESCRIPTION
When a storage was not returning an array, `$stored` was initialized with an empty array and an empty scope. The result of that is that when you tried to get an access token with a scope, even if it was set in the `supported_scopes` config variable, the server was always returning a `An unsupported scope was requested.` error.

With this PR, `$scope` is now initialized with `supported_scopes` config variable as default scope.
