### PR TITLE
Use null as the default supported_scopes value.

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -362,7 +362,7 @@ class OAuth2 {
       self::CONFIG_ENFORCE_INPUT_REDIRECT => TRUE,
 
       self::CONFIG_ENFORCE_STATE          => FALSE,
-      self::CONFIG_SUPPORTED_SCOPES       => array(), // This is expected to be passed in on construction. Scopes can be an aribitrary string.
+      self::CONFIG_SUPPORTED_SCOPES       => null, // This is expected to be passed in on construction. Scopes can be an aribitrary string.
     );
   }
 


### PR DESCRIPTION
This fixes the following ticket.

FriendsOfSymfony/FOSOAuthServerBundle#164
#37 tries to default the value as null but since it is initialised as an empty array, it will never be fetched as null by `getVariable()`. Since FOSOAuthServerBundle implements the scope field as string, doctrine will throw an error because scope is passed in as an array.

Further more, `checkScope()` handles string scopes nicely so there is no problem with a string value.
