### PR TITLE
Client can define enforce_state and lifetime parameters

### DIFF
--- a/lib/OAuth2/Model/IOAuth2Client.php
+++ b/lib/OAuth2/Model/IOAuth2Client.php
@@ -6,5 +6,10 @@ interface IOAuth2Client {
 
     public function getPublicId();
     public function getRedirectUris();
+
+    public function getAccessTokenLifetime();
+    public function getRefreshTokenLifetime();
+    public function getAuthCodeLifetime();
+    public function getEnforceState();
 }
 

--- a/lib/OAuth2/Model/OAuth2Client.php
+++ b/lib/OAuth2/Model/OAuth2Client.php
@@ -8,14 +8,26 @@ class OAuth2Client implements IOAuth2Client {
     private $redirectUris;
     private $secret;
 
-    public function __construct($id, $secret = NULL, array $redirectUris = array()) {
-        $this->setPublicId($id);
-        $this->setSecret($secret);
-        $this->setRedirectUris($redirectUris);
+    private $access_token_lifetime;
+    private $refresh_token_lifetime;
+    private $authcode_lifetime;
+    private $enforce_state;
+
+    public function __construct($id, $secret = NULL, array $redirectUris = array(), $access_token_lifetime = null, $refresh_token_lifetime = null, $authcode_lifetime = null, $enforce_state = null) {
+        
+        $this->setPublicId($id)
+             ->setSecret($secret)
+             ->setRedirectUris($redirectUris)
+             ->setAccessTokenLifetime($access_token_lifetime)
+             ->setRefreshTokenLifetime($refresh_token_lifetime)
+             ->setAuthCodeLifetime($authcode_lifetime)
+             ->setEnforceState($enforce_state);
     }
 
     public function setPublicId($id) {
         $this->id = $id;
+
+        return $this;
     }
 
     public function getPublicId() {
@@ -24,6 +36,8 @@ class OAuth2Client implements IOAuth2Client {
 
     public function setSecret($secret) {
         $this->secret = $secret;
+
+        return $this;
     }
 
     public function checkSecret($secret) {
@@ -32,10 +46,56 @@ class OAuth2Client implements IOAuth2Client {
 
     public function setRedirectUris(array $redirectUris) {
         $this->redirectUris = $redirectUris;
+
+        return $this;
     }
 
     public function getRedirectUris() {
         return $this->redirectUris;
+    }
+
+    public function setAccessTokenLifetime($access_token_lifetime) {
+        $this->access_token_lifetime = $access_token_lifetime;
+
+        return $this;
+    }
+
+    public function getAccessTokenLifetime() {
+
+        return $this->access_token_lifetime;
+    }
+
+    public function setRefreshTokenLifetime($refresh_token_lifetime) {
+        $this->refresh_token_lifetime = $refresh_token_lifetime;
+
+        return $this;
+    }
+
+    public function getRefreshTokenLifetime() {
+
+        return $this->refresh_token_lifetime;
+    }
+
+    public function setAuthCodeLifetime($authcode_lifetime) {
+        $this->authcode_lifetime = $authcode_lifetime;
+
+        return $this;
+    }
+
+    public function getAuthCodeLifetime() {
+
+        return $this->authcode_lifetime;
+    }
+
+    public function setEnforceState($enforce_state) {
+        $this->enforce_state = $enforce_state;
+
+        return $this;
+    }
+
+    public function getEnforceState() {
+
+        return $this->enforce_state;
     }
 }
 

--- a/tests/OAuth2/Tests/Fixtures/OAuth2StorageStub.php
+++ b/tests/OAuth2/Tests/Fixtures/OAuth2StorageStub.php
@@ -5,15 +5,16 @@ namespace OAuth2\Tests\Fixtures;
 use OAuth2\OAuth2;
 use OAuth2\Model\IOAuth2Client;
 use OAuth2\Model\OAuth2AccessToken;
-use OAuth2\IOAuth2Storage;
+use OAuth2\IOAuth2RefreshTokens;
 
 /**
  * IOAuth2Storage stub for testing
  */
-class OAuth2StorageStub implements IOAuth2Storage
+class OAuth2StorageStub implements IOAuth2RefreshTokens
 {
     private $clients = array();
     private $accessTokens = array();
+    private $refreshTokens = array();
     private $allowedGrantTypes = array(OAuth2::GRANT_TYPE_AUTH_CODE);
 
     public function addClient(IOAuth2Client $client)
@@ -69,5 +70,29 @@ class OAuth2StorageStub implements IOAuth2Storage
     public function checkRestrictedGrantType(IOAuth2Client $client, $grant_type)
     {
         return in_array($grant_type, $this->allowedGrantTypes);
+    }
+
+    public function getRefreshToken($refresh_token) {
+
+        if (isset($this->refreshTokens[$refresh_token])) {
+            return $this->refreshTokens[$refresh_token];
+        }
+    }
+
+    public function getLastRefreshToken()
+    {
+        return end($this->refreshTokens);
+    }
+
+    public function createRefreshToken($refresh_token, IOAuth2Client $client, $data, $expires, $scope = NULL) {
+
+        $token = new OAuth2AccessToken($client->getPublicId(), $refresh_token, $expires, $scope, $data);
+        $this->refreshTokens[$refresh_token] = $token;
+    }
+    public function unsetRefreshToken($refresh_token) {
+
+        if (isset($this->refreshTokens[$refresh_token])) {
+            unset($this->refreshTokens[$refresh_token]);
+        }
     }
 }

--- a/tests/OAuth2EnforceStateTest.php
+++ b/tests/OAuth2EnforceStateTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use OAuth2\OAuth2;
+use OAuth2\Model\OAuth2Client;
+use OAuth2\Tests\Fixtures\OAuth2GrantCodeStub;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Enforce State test case.
+ */
+class OAuth2EnforceStateTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test for Enforce State
+     * @dataProvider dataEnforceState
+     */
+    public function testEnforceState(OAuth2Client $client, array $server_options, Request $request, $exception = null, $exceptionMessage = null, $exceptionDescription = null, $state_expected = false)
+    {
+        $stub = new OAuth2GrantCodeStub;
+        $stub->addClient( $client );
+
+        try {
+            $oauth2 = new OAuth2($stub, $server_options);
+
+            $data = new \stdClass;
+
+            $response = $oauth2->finishClientAuthorization(true, $data, $request);
+
+            if ($state_expected === true) {
+
+                $this->assertRegexp('#^http://www\.example\.com/\?foo=bar&state=42&code=#', $response->headers->get('location'));
+            } else {
+
+                $this->assertRegexp('#^http://www\.example\.com/\?foo=bar&code=#', $response->headers->get('location'));
+            }
+
+            if ($exception !== null) {
+                $this->fail('The expected exception was not thrown');
+            }
+        } catch (\Exception $e) {
+            if (!$exception || !($e instanceof $exception)) {
+                throw $e;
+            }
+            $this->assertSame($exceptionMessage, $e->getMessage());
+            $this->assertSame($exceptionDescription, $e->getDescription());
+        }
+    }
+
+    /**
+     * Dataprovider for testEnforceState().
+     */
+    public function dataEnforceState()
+    {
+        return array(
+            /* Data without state passed in the request */
+            // Enforce state set to false by default
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, null),
+                array(
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                )),
+                null,
+                null,
+                null,
+                false,
+            ),
+
+            // Enforce State required by server
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, null),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                )),
+                'OAuth2\OAuth2RedirectException',
+                OAuth2::ERROR_INVALID_REQUEST,
+                'The state parameter is required.',
+            ),
+
+            // Enforce State required by server, but not by client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, false),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                )),
+                null,
+                null,
+                null,
+                false,
+            ),
+
+            // Enforce State not required by server, but by client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, true),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => false
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                )),
+                'OAuth2\OAuth2RedirectException',
+                OAuth2::ERROR_INVALID_REQUEST,
+                'The state parameter is required.',
+            ),
+
+            // Enforce State required by server and client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, true),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                )),
+                'OAuth2\OAuth2RedirectException',
+                OAuth2::ERROR_INVALID_REQUEST,
+                'The state parameter is required.',
+            ),
+
+            /* Dataset with state passed in the request */
+            // Enforce state set to false by default
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, null),
+                array(
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                    'state' => '42'
+                )),
+                null,
+                null,
+                null,
+                true,
+            ),
+
+            // Enforce State required by server
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, null),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                    'state' => '42'
+                )),
+                null,
+                null,
+                null,
+                true,
+            ),
+
+            // Enforce State required by server, but not by client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, false),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                    'state' => '42'
+                )),
+                null,
+                null,
+                null,
+                true,
+            ),
+
+            // Enforce State not required by server, but by client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, true),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => false
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                    'state' => '42'
+                )),
+                null,
+                null,
+                null,
+                true,
+            ),
+
+            // Enforce State required by server and client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null, true),
+                array(
+                    OAuth2::CONFIG_ENFORCE_STATE => true
+                ),
+                new Request(array(
+                    'client_id' => 'blah',
+                    'redirect_uri' => 'http://www.example.com/?foo=bar',
+                    'response_type' => 'code',
+                    'state' => '42'
+                )),
+                null,
+                null,
+                null,
+                true,
+            ),
+        );
+    }
+}

--- a/tests/OAuth2TokenLifetimeTest.php
+++ b/tests/OAuth2TokenLifetimeTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use OAuth2\OAuth2;
+use OAuth2\Model\OAuth2Client;
+use OAuth2\Tests\Fixtures\OAuth2GrantCodeStub;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Token lifetime test case.
+ */
+class OAuth2TokenLifetimeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test for Access Tokens
+     * @dataProvider dataTokenLifetime
+     */
+    public function testTokenLifetime(OAuth2Client $client, array $server_options, $exception = null, $exceptionMessage = null, $exceptionDescription = null, $authcode_lifetime_expected = null, $access_token_lifetime_expected = null, $refresh_token_lifetime_expected = null)
+    {
+        $stub = new OAuth2GrantCodeStub;
+        $stub->addClient( $client );
+
+        try {
+            $oauth2 = new OAuth2($stub, $server_options);
+
+            $authcode_request = new Request(array(
+                'client_id' => 'blah',
+                'redirect_uri' => 'http://www.example.com/?foo=bar',
+                'response_type' => 'code',
+            ));
+            $data = new \stdClass;
+
+            $oauth2->finishClientAuthorization(true, $data, $authcode_request);
+            $code = $stub->getLastAuthCode();
+
+            $acces_token_request = new Request(array(
+                'grant_type' => OAuth2::GRANT_TYPE_AUTH_CODE,
+                'client_id' => 'blah',
+                'client_secret' => 'foo',
+                'redirect_uri' => 'http://www.example.com/?foo=bars',
+                'code'=> $code->getToken()
+            ));
+            $oauth2->grantAccessToken($acces_token_request);
+            $access_token = $stub->getLastAccessToken();
+            $refresh_token = $stub->getLastRefreshToken();
+
+            $this->assertSame($authcode_lifetime_expected, $code->getExpiresIn());
+            $this->assertSame($access_token_lifetime_expected, $access_token->getExpiresIn());
+            $this->assertSame($refresh_token_lifetime_expected, $refresh_token->getExpiresIn());
+
+            if ($exception !== null) {
+                $this->fail('The expected exception was not thrown');
+            }
+        } catch (\Exception $e) {
+            if (!$exception || !($e instanceof $exception)) {
+                throw $e;
+            }
+            $this->assertSame($exceptionMessage, $e->getMessage());
+            $this->assertSame($exceptionDescription, $e->getDescription());
+        }
+    }
+
+    /**
+     * Dataprovider for testTokenLifetime().
+     */
+    public function dataTokenLifetime()
+    {
+        return array(
+            // Lifetime defined by server (default values)
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null),
+                array(
+                ),
+                null,
+                null,
+                null,
+                30,
+                3600,
+                1209600,
+            ),
+
+            // Lifetime defined by server (custom values)
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, null),
+                array(
+                    OAuth2::CONFIG_AUTH_LIFETIME => 60,
+                    OAuth2::CONFIG_ACCESS_LIFETIME => 7200,
+                    OAuth2::CONFIG_REFRESH_LIFETIME => 2419200,
+                ),
+                null,
+                null,
+                null,
+                60,
+                7200,
+                2419200,
+            ),
+
+            // Auth Code Lifetime defined by client and other lifetimes defined by server
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, null, 120),
+                array(
+                    OAuth2::CONFIG_AUTH_LIFETIME => 30,
+                    OAuth2::CONFIG_ACCESS_LIFETIME => 7200,
+                    OAuth2::CONFIG_REFRESH_LIFETIME => 2419200,
+                ),
+                null,
+                null,
+                null,
+                120,
+                7200,
+                2419200,
+            ),
+
+            // Access Token Lifetime defined by client and other lifetimes defined by server
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), 1000, null, null),
+                array(
+                    OAuth2::CONFIG_AUTH_LIFETIME => 60,
+                    OAuth2::CONFIG_ACCESS_LIFETIME => 7200,
+                    OAuth2::CONFIG_REFRESH_LIFETIME => 2419200,
+                ),
+                null,
+                null,
+                null,
+                60,
+                1000,
+                2419200,
+            ),
+
+            // Refresh Token Lifetime defined by client and other lifetimes defined by server
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), null, 10000, null),
+                array(
+                    OAuth2::CONFIG_AUTH_LIFETIME => 60,
+                    OAuth2::CONFIG_ACCESS_LIFETIME => 7200,
+                    OAuth2::CONFIG_REFRESH_LIFETIME => 2419200,
+                ),
+                null,
+                null,
+                null,
+                60,
+                7200,
+                10000,
+            ),
+
+            // All Lifetimes defined by client
+            array(
+                new OAuth2Client('blah', 'foo', array('http://www.example.com/'), 20, 30, 10),
+                array(
+                    OAuth2::CONFIG_AUTH_LIFETIME => 60,
+                    OAuth2::CONFIG_ACCESS_LIFETIME => 7200,
+                    OAuth2::CONFIG_REFRESH_LIFETIME => 2419200,
+                ),
+                null,
+                null,
+                null,
+                10,
+                20,
+                30,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Client should be able to override enforce_state parameter and define custom lifetime for tokens (auth codes, access tokens and refresh tokens).

This PR add this functionnality and tests.

**It changes the client interface, so that this PR breaks compatibility and requires to bump version number.**
