### PR TITLE
check for path traversal in redirect_uri

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -1304,6 +1304,19 @@ class OAuth2 {
     if (!$inputUri || !$storedUris) {
       return false; // if either one is missing, assume INVALID
     }
+
+    $parsed = parse_url($inputUri);
+    if (!$parsed) {
+        return false;
+    }
+    if (isset($parsed['path'])) {
+        $path = urldecode($parsed['path']);
+        // check for 'path traversal'
+        if (preg_match('#/\.\.?(/|$)#', $path)) {
+            return false;
+        }
+    }
+
     if (!is_array($storedUris)) {
       $storedUris = array($storedUris);
     }


### PR DESCRIPTION
`/../`in a redirect URI allows to redirect to non-allowed URIs: http://homakov.blogspot.fr/2014/02/how-i-hacked-github-again.html

This change checks if the URI contains `/../` or ends with `/..`, and fails validation if it does. (`/./`and `/.`are disallowed too.)
