### PR TITLE
travis-ci: test against hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
 
 before_script:
     - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Tests pass against HHVM, with #57.

This PR enables testing against HHVM in Travis.
