### PR TITLE
Set getJsonHeaders method to protected

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -1452,7 +1452,7 @@ class OAuth2
      *
      * @ingroup oauth2_section_5
      */
-    private function getJsonHeaders()
+    protected function getJsonHeaders()
     {
         return array(
             'Content-Type' => 'application/json',


### PR DESCRIPTION
By setting the method from private to protected, it allows someone to
extends OAuth2.php and override grantAccessToken without having to
duplicate this method.
