### PR TITLE
Implementation that would satisfy grant extensions that can specify a time limit on the access token (fixes #66)

### DIFF
--- a/tests/OAuth2/Tests/Fixtures/OAuth2GrantExtensionLifetimeStub.php
+++ b/tests/OAuth2/Tests/Fixtures/OAuth2GrantExtensionLifetimeStub.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OAuth2\Tests\Fixtures;
+
+use OAuth2\OAuth2;
+use OAuth2\IOAuth2GrantExtension;
+use OAuth2\OAuth2ServerException;
+use OAuth2\Model\IOAuth2Client;
+
+class OAuth2GrantExtensionLifetimeStub extends OAuth2StorageStub implements IOAuth2GrantExtension
+{
+    protected $facebookIds = array();
+
+    public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders)
+    {
+        if ('http://company.com/fb_access_token_time_limited' !== $uri) {
+            throw new OAuth2ServerException(OAuth2::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
+        }
+
+        if (!isset($inputData['fb_access_token'])) {
+            return false;
+        }
+
+        $fbAccessToken = $inputData['fb_access_token'];
+        $fbId = $this->getFacebookIdFromFacebookAccessToken($fbAccessToken);
+
+        if (!isset($this->facebookIds[$fbId])) {
+            return false;
+        }
+
+        return array(
+            'data' => array('user_id' => $fbId),
+            'access_token_lifetime' => 86400,
+            'issue_refresh_token' => false
+        );
+    }
+
+    public function addFacebookId($id)
+    {
+        $this->facebookIds[$id] = $id;
+    }
+
+    /**
+     * Let's assume a fb access token looks like "something_fbid"
+     *
+     * In real life, we would verify the access token is valid, and get the facebook_id of the
+     * user via GET http://graph.facebook.com/me
+     */
+    protected function getFacebookIdFromFacebookAccessToken($fbAccessToken)
+    {
+        return substr($fbAccessToken, strpos($fbAccessToken, '_') + 1);
+    }
+}


### PR DESCRIPTION
I changed OAuth2::createAccessToken to require 3 additional parameters: $access_token_lifetime, $refresh_token, and $refresh_token_lifetime.  

Previously the refresh token and access token lifetimes were determined as part of this function.  Now those are passed in.  

The same code that determined those lifetimes is used (i.e. getVariable(self::CONFIG_<TOKENTYPE>_LIFETIME, but if a grant extension returns access_token_lifetime, refresh_token, or refresh_token_lifetime, that's used instead of the getVariable() result.

I've included a test that essentially duplicates the grant extension stub and shows that it works.
