### PR TITLE
Refresh token must not be issued using Implicit and Client Credentials grant types

### DIFF
--- a/lib/OAuth2/OAuth2.php
+++ b/lib/OAuth2/OAuth2.php
@@ -939,6 +939,10 @@ class OAuth2
             throw new OAuth2ServerException(self::HTTP_BAD_REQUEST, self::ERROR_INVALID_GRANT);
         }
 
+        if (!is_array($stored)) {
+            $stored = array();
+        }
+        $stored += array('issue_refresh_token' => false);
         return $stored;
     }
 
@@ -1221,7 +1225,7 @@ class OAuth2
                     $scope
                 );
             } elseif ($params["response_type"] == self::RESPONSE_TYPE_ACCESS_TOKEN) {
-                $result["fragment"] = $this->createAccessToken($params["client"], $data, $scope);
+                $result["fragment"] = $this->createAccessToken($params["client"], $data, $scope, null, false);
             }
         }
 

--- a/tests/OAuth2/Tests/Fixtures/OAuth2StorageStub.php
+++ b/tests/OAuth2/Tests/Fixtures/OAuth2StorageStub.php
@@ -5,15 +5,19 @@ namespace OAuth2\Tests\Fixtures;
 use OAuth2\OAuth2;
 use OAuth2\Model\IOAuth2Client;
 use OAuth2\Model\OAuth2AccessToken;
+use OAuth2\Model\OAuth2RefreshToken;
 use OAuth2\IOAuth2Storage;
+use OAuth2\IOAuth2GrantClient;
+use OAuth2\IOAuth2RefreshTokens;
 
 /**
  * IOAuth2Storage stub for testing
  */
-class OAuth2StorageStub implements IOAuth2Storage
+class OAuth2StorageStub implements IOAuth2Storage, IOAuth2GrantClient, IOAuth2RefreshTokens
 {
     private $clients = array();
     private $accessTokens = array();
+    private $refreshTokens = array();
     private $allowedGrantTypes = array(OAuth2::GRANT_TYPE_AUTH_CODE);
 
     public function addClient(IOAuth2Client $client)
@@ -36,6 +40,11 @@ class OAuth2StorageStub implements IOAuth2Storage
     public function checkClientCredentials(IOAuth2Client $client, $clientSecret = null)
     {
         return $client->checkSecret($clientSecret);
+    }
+
+    public function checkClientCredentialsGrant(IOAuth2Client $client, $clientSecret)
+    {
+        return $this->checkClientCredentials($client, $clientSecret);
     }
 
     public function createAccessToken($oauthToken, IOAuth2Client $client, $data, $expires, $scope = null)
@@ -70,5 +79,26 @@ class OAuth2StorageStub implements IOAuth2Storage
     public function checkRestrictedGrantType(IOAuth2Client $client, $grantType)
     {
         return in_array($grantType, $this->allowedGrantTypes);
+    }
+
+    public function getRefreshToken($refreshToken)
+    {
+        if (isset($this->refreshTokens[$refreshToken])) {
+            return $this->refreshTokens[$refreshToken];
+        }
+    }
+
+    public function createRefreshToken($refreshToken, IOAuth2Client $client, $data, $expires, $scope = null)
+    {
+        $token = new OAuth2RefreshToken($client->getPublicId(), $refreshToken, $expires, $scope, $data);
+
+        $this->refreshToken[$refreshToken] = $token;
+    }
+
+    public function unsetRefreshToken($refreshToken)
+    {
+        if (isset($this->refreshTokens[$refreshToken])) {
+            unset($this->refreshTokens[$refreshToken]);
+        }
     }
 }


### PR DESCRIPTION
This commit fixes bug #21.
Now refresh token are not issued using Implicit and Client Credentials
grant types (thanks to @jeffxpx).
