### PR TITLE
bootstrap.php removed

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
 >
   <testsuites>
     <testsuite name="oauth2-php Test Suite">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-$loader = require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Now `vendor/autoload.php` is used directly.
