### PR TITLE
Allow Symfony HTTPFoundation 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/http-foundation": "~2.0"
+        "symfony/http-foundation": "~2.0|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Just been through the code and we seem lucky enough that the interfaces used on this lib from Request and Response haven't changed since symfony 2.0.

This is required by any dependent package that wants to use symfony 3, such as FOSOauthServerBundle.