### PR TITLE
Allow to set a TokenGenerator to override default implementation.

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -5,6 +5,7 @@ namespace OAuth2;
 use OAuth2\Model\IOAuth2AccessToken;
 use OAuth2\Model\IOAuth2AuthCode;
 use OAuth2\Model\IOAuth2Client;
+use OAuth2\TokenGenerator\TokenGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -60,6 +61,13 @@ class OAuth2
      * @var IOAuth2Storage
      */
     protected $storage;
+
+    /**
+     * Token Generator (Random, JWT, etc.)
+     *
+     * @var TokenGeneratorInterface
+     */
+    private $tokenGenerator;
 
     /**
      * Keep track of the old refresh token. So we can unset
@@ -403,6 +411,20 @@ class OAuth2
         foreach ($config as $name => $value) {
             $this->setVariable($name, $value);
         }
+    }
+
+    /**
+     * Sets a TokenGenerator to override default implementation.
+     *
+     * @param TokenGeneratorInterface $tokenGenerator
+     *
+     * @return OAuth2 The application (for chained calls of this method)
+     */
+    public function setTokenGenerator(TokenGeneratorInterface $tokenGenerator)
+    {
+        $this->tokenGenerator = $tokenGenerator;
+
+        return $this;
     }
 
     /**
@@ -1331,8 +1353,12 @@ class OAuth2
      */
     public function createAccessToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null)
     {
+        $genAccessToken = $this->tokenGenerator
+            ? $this->tokenGenerator->genAccessToken($client, $data, $scope, $access_token_lifetime, $issue_refresh_token, $refresh_token_lifetime)
+            : $this->genAccessToken()
+        ;
         $token = array(
-            "access_token" => $this->genAccessToken(),
+            "access_token" => $genAccessToken,
             "expires_in" => ($access_token_lifetime ?: $this->getVariable(self::CONFIG_ACCESS_LIFETIME)),
             "token_type" => $this->getVariable(self::CONFIG_TOKEN_TYPE),
             "scope" => $scope,
@@ -1348,7 +1374,10 @@ class OAuth2
 
         // Issue a refresh token also, if we support them
         if ($this->storage instanceof IOAuth2RefreshTokens && $issue_refresh_token === true) {
-            $token["refresh_token"] = $this->genAccessToken();
+            $token["refresh_token"] = $this->tokenGenerator
+                ? $this->tokenGenerator->genRefreshToken($client, $data, $scope, $access_token_lifetime, $issue_refresh_token, $refresh_token_lifetime)
+                : $this->genAccessToken()
+            ;
             $this->storage->createRefreshToken(
                 $token["refresh_token"],
                 $client,
@@ -1390,7 +1419,10 @@ class OAuth2
      */
     private function createAuthCode(IOAuth2Client $client, $data, $redirectUri, $scope = null)
     {
-        $code = $this->genAuthCode();
+        $code = $this->tokenGenerator
+            ? $this->tokenGenerator->genAuthCode($client, $data, $scope, $redirectUri)
+            : $this->genAuthCode()
+        ;
         $this->storage->createAuthCode(
             $code,
             $client,
@@ -1413,6 +1445,8 @@ class OAuth2
      *
      * @ingroup oauth2_section_4
      * @see     OAuth2::genAuthCode()
+     *
+     * @deprecated since 1.3, will be removed in 2.0. Use a TokenGenerator instead.
      */
     protected function genAccessToken()
     {
@@ -1446,6 +1480,8 @@ class OAuth2
      * @see     OAuth2::genAccessToken()
      *
      * @ingroup oauth2_section_4
+     *
+     * @deprecated since 1.3, will be removed in 2.0. Use a TokenGenerator instead.
      */
     protected function genAuthCode()
     {

--- a/lib/TokenGenerator/RandomTokenGenerator.php
+++ b/lib/TokenGenerator/RandomTokenGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OAuth2\TokenGenerator;
+
+use OAuth2\Model\IOAuth2Client;
+
+class RandomTokenGenerator implements TokenGeneratorInterface
+{
+    public function genAccessToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null)
+    {
+        if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
+            $randomData = file_get_contents('/dev/urandom', false, null, 0, 100);
+        } elseif (function_exists('openssl_random_pseudo_bytes')) { // Get 100 bytes of pseudo-random data
+            $bytes = openssl_random_pseudo_bytes(100, $strong);
+            if (true === $strong && false !== $bytes) {
+                $randomData = $bytes;
+            }
+        }
+        // Last resort: mt_rand
+        if (empty($randomData)) { // Get 108 bytes of (pseudo-random, insecure) data
+            $randomData = mt_rand() . mt_rand() . mt_rand() . uniqid(mt_rand(), true) . microtime(true) . uniqid(
+                    mt_rand(),
+                    true
+                );
+        }
+
+        return rtrim(strtr(base64_encode(hash('sha256', $randomData)), '+/', '-_'), '=');
+    }
+
+    public function genRefreshToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null)
+    {
+        return $this->genAccessToken($client, $data);
+    }
+
+    public function genAuthCode(IOAuth2Client $client, $data, $scope = null, $redirectUri = null)
+    {
+        return $this->genAccessToken($client, $data);
+    }
+}

--- a/lib/TokenGenerator/TokenGeneratorInterface.php
+++ b/lib/TokenGenerator/TokenGeneratorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OAuth2\TokenGenerator;
+
+use OAuth2\Model\IOAuth2Client;
+
+interface TokenGeneratorInterface
+{
+    public function genAccessToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null);
+
+    public function genRefreshToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null);
+
+    public function genAuthCode(IOAuth2Client $client, $data, $scope = null, $redirectUri = null);
+}

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -1057,6 +1057,28 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testSetTokenGenerator()
+    {
+        $request = new Request(
+            array('grant_type' => OAuth2::GRANT_TYPE_CLIENT_CREDENTIALS, 'client_id' => 'my_little_app', 'client_secret' => 'b')
+        );
+
+        $storage = new OAuth2StorageStub;
+        $storage->addClient(new OAuth2Client('my_little_app', 'b'));
+        $storage->setAllowedGrantTypes(array(OAuth2::GRANT_TYPE_CLIENT_CREDENTIALS));
+
+        $tokenGenerator = $this->getMockBuilder('OAuth2\TokenGenerator\TokenGeneratorInterface')->getMock();
+        $tokenGenerator->expects($this->once())->method('genAccessToken')->willReturn('aa.bb.cc');
+
+        $this->fixture = new OAuth2($storage);
+        $this->fixture->setTokenGenerator($tokenGenerator);
+
+        $response = $this->fixture->grantAccessToken($request);
+
+        // Successful token grant will return a JSON encoded token WITHOUT a refresh token:
+        $this->assertRegExp('/^{"access_token":"aa\.bb\.cc","expires_in":[^"]+,"token_type":"bearer","scope":null}$/', $response->getContent());
+    }
+
     public function getTestGetBearerTokenData()
     {
         $data = array();

--- a/tests/TokenGenerator/RandomTokenGeneratorTest.php
+++ b/tests/TokenGenerator/RandomTokenGeneratorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use OAuth2\TokenGenerator\RandomTokenGenerator;
+
+class RandomTokenGeneratorTest extends PHPUnit_Framework_TestCase
+{
+    public function testGenerateAccessToken()
+    {
+        $tokenGenerator = new RandomTokenGenerator();
+        $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')->getMock();
+
+        $this->assertNotEmpty($tokenGenerator->genAccessToken($client, null));
+    }
+
+    public function testGenerateRefreshToken()
+    {
+        $tokenGenerator = new RandomTokenGenerator();
+        $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')->getMock();
+
+        $this->assertNotEmpty($tokenGenerator->genRefreshToken($client, null));
+    }
+
+    public function testGenerateAuthCode()
+    {
+        $tokenGenerator = new RandomTokenGenerator();
+        $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')->getMock();
+
+        $this->assertNotEmpty($tokenGenerator->genAuthCode($client, null));
+    }
+}


### PR DESCRIPTION
It eases the use of JWT or other token types.

Could also fix https://github.com/FriendsOfSymfony/oauth2-php/issues/86
