### PR TITLE
Properly unescape redirect_uris before comparing them

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -890,7 +890,7 @@ class OAuth2
 
         // Validate the redirect URI. If a redirect URI has been provided on input, it must be validated
         if ($input["redirect_uri"] && !$this->validateRedirectUri(
-                $input["redirect_uri"],
+                urldecode($input["redirect_uri"]),
                 $authCode->getRedirectUri()
             )
         ) {


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/issues/460