### PR TITLE
Fixed token type "Bearer" to start with uppercase letter.

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -256,7 +256,7 @@ class OAuth2
      *
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-7.1
      */
-    const TOKEN_TYPE_BEARER = 'bearer';
+    const TOKEN_TYPE_BEARER = 'Bearer';
     const TOKEN_TYPE_MAC = 'mac'; // Currently unsupported
 
     /**

--- a/tests/OAuth2ImplicitGrantTypeTest.php
+++ b/tests/OAuth2ImplicitGrantTypeTest.php
@@ -38,7 +38,7 @@ class OAuth2ImplicitGrantTypeTest extends PHPUnit_Framework_TestCase
                 'state' => '42',
         )));
 
-        $this->assertRegExp('/^http:\/\/www.example.com\/\?foo=bar#state=42&access_token=[^"]+&expires_in=3600&token_type=bearer$/', $response->headers->get('Location'));
+        $this->assertRegExp('/^http:\/\/www.example.com\/\?foo=bar#state=42&access_token=[^"]+&expires_in=3600&token_type=Bearer$/', $response->headers->get('Location'));
     }
 
     /**

--- a/tests/OAuth2OutputTest.php
+++ b/tests/OAuth2OutputTest.php
@@ -35,7 +35,7 @@ class OAuth2OutputTest extends PHPUnit_Framework_TestCase
         $response = $this->fixture->grantAccessToken($request);
 
         // Successful token grant will return a JSON encoded token:
-        $this->assertRegexp('/{"access_token":".*","expires_in":\d+,"token_type":"bearer"/', $response->getContent());
+        $this->assertRegexp('/{"access_token":".*","expires_in":\d+,"token_type":"Bearer"/', $response->getContent());
     }
 
     /**
@@ -58,7 +58,7 @@ class OAuth2OutputTest extends PHPUnit_Framework_TestCase
         $response = $this->fixture->grantAccessToken($request);
 
         // Successful token grant will return a JSON encoded token:
-        $this->assertRegexp('/{"access_token":".*","expires_in":\d+,"token_type":"bearer"/', $response->getContent());
+        $this->assertRegexp('/{"access_token":".*","expires_in":\d+,"token_type":"Bearer"/', $response->getContent());
     }
 
 // Utility methods

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -215,7 +215,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
         $response = $this->fixture->grantAccessToken($request);
 
         // Successful token grant will return a JSON encoded token WITHOUT a refresh token:
-        $this->assertRegExp('/^{"access_token":"[^"]+","expires_in":[^"]+,"token_type":"bearer","scope":null}$/', $response->getContent());
+        $this->assertRegExp('/^{"access_token":"[^"]+","expires_in":[^"]+,"token_type":"Bearer","scope":null}$/', $response->getContent());
     }
 
     /**
@@ -426,7 +426,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer","scope":null}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer","scope":null}', $response->getContent());
 
         $token = $stub->getLastAccessToken();
         $this->assertSame('cid', $token->getClientId());
@@ -491,7 +491,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer","scope":"scope1 scope2"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer","scope":"scope1 scope2"}', $response->getContent());
 
         $token = $stub->getLastAccessToken();
         $this->assertSame('cid', $token->getClientId());
@@ -525,7 +525,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer","scope":"scope1"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer","scope":"scope1"}', $response->getContent());
 
         $token = $stub->getLastAccessToken();
         $this->assertSame('cid', $token->getClientId());
@@ -558,7 +558,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer","scope":"scope1 scope2"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer","scope":"scope1 scope2"}', $response->getContent());
 
         $token = $stub->getLastAccessToken();
         $this->assertSame('cid', $token->getClientId());
@@ -645,7 +645,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer"}', $response->getContent());
     }
 
     /**
@@ -681,7 +681,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":86400,"token_type":"bearer"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":86400,"token_type":"Bearer"}', $response->getContent());
     }
 
     /**
@@ -718,7 +718,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
             array('date' => null)
         ));
 
-        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"bearer","scope":null,"refresh_token":"[^"]+"}', $response->getContent());
+        $this->assertRegExp('{"access_token":"[^"]+","expires_in":3600,"token_type":"Bearer","scope":null,"refresh_token":"[^"]+"}', $response->getContent());
 
         $token = $stub->getLastAccessToken();
         $this->assertSame('cid', $token->getClientId());


### PR DESCRIPTION
This resolved issue #98 and fixes problems wear clients want to use the provided "token_type" to return the token to the server. Cause problems with FOSOAuthServerBundle.

All tests pass with this change.