### PR TITLE
Fixing HTTP status code definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
     - hhvm
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/http-foundation": "~2.0|~3.0|~4.0"
+        "symfony/http-foundation": "~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": "^5.5.9|>=7.0.8",
         "symfony/http-foundation": "~3.0|~4.0"
     },
     "require-dev": {

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -270,11 +270,11 @@ class OAuth2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4.1.2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-5.2
      */
-    const HTTP_FOUND = '302 Found';
-    const HTTP_BAD_REQUEST = '400 Bad Request';
-    const HTTP_UNAUTHORIZED = '401 Unauthorized';
-    const HTTP_FORBIDDEN = '403 Forbidden';
-    const HTTP_UNAVAILABLE = '503 Service Unavailable';
+    const HTTP_FOUND = '302';
+    const HTTP_BAD_REQUEST = '400';
+    const HTTP_UNAUTHORIZED = '401';
+    const HTTP_FORBIDDEN = '403';
+    const HTTP_UNAVAILABLE = '503';
 
     /**
      * @}

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -270,11 +270,11 @@ class OAuth2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4.1.2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-5.2
      */
-    const HTTP_FOUND = 302;
-    const HTTP_BAD_REQUEST = 400;
-    const HTTP_UNAUTHORIZED = 401;
-    const HTTP_FORBIDDEN = 403;
-    const HTTP_UNAVAILABLE = 503;
+    const HTTP_FOUND = Response::HTTP_FOUND;
+    const HTTP_BAD_REQUEST = Response::HTTP_BAD_REQUEST;
+    const HTTP_UNAUTHORIZED = Response::HTTP_UNAUTHORIZED;
+    const HTTP_FORBIDDEN = Response::HTTP_FORBIDDEN;
+    const HTTP_UNAVAILABLE = Response::HTTP_SERVICE_UNAVAILABLE;
 
     /**
      * @}

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -270,11 +270,11 @@ class OAuth2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4.1.2
      * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-5.2
      */
-    const HTTP_FOUND = '302';
-    const HTTP_BAD_REQUEST = '400';
-    const HTTP_UNAUTHORIZED = '401';
-    const HTTP_FORBIDDEN = '403';
-    const HTTP_UNAVAILABLE = '503';
+    const HTTP_FOUND = 302;
+    const HTTP_BAD_REQUEST = 400;
+    const HTTP_UNAUTHORIZED = 401;
+    const HTTP_FORBIDDEN = 403;
+    const HTTP_UNAVAILABLE = 503;
 
     /**
      * @}

--- a/lib/OAuth2RedirectException.php
+++ b/lib/OAuth2RedirectException.php
@@ -2,6 +2,8 @@
 
 namespace OAuth2;
 
+use Symfony\Component\HttpFoundation\Response;
+
 /**
  * Redirect the end-user's user agent with error message.
  *
@@ -37,7 +39,7 @@ class OAuth2RedirectException extends OAuth2ServerException
      */
     public function __construct($redirectUri, $error, $errorDescription = null, $state = null, $method = OAuth2::TRANSPORT_QUERY)
     {
-        parent::__construct(OAuth2::HTTP_FOUND, $error, $errorDescription);
+        parent::__construct(Response::HTTP_FOUND, $error, $errorDescription);
 
         $this->method = $method;
         $this->redirectUri = $redirectUri;

--- a/tests/Fixtures/OAuth2GrantExtensionJwtBearer.php
+++ b/tests/Fixtures/OAuth2GrantExtensionJwtBearer.php
@@ -7,6 +7,7 @@ use OAuth2\IOAuth2GrantExtension;
 use OAuth2\OAuth2ServerException;
 use OAuth2\Model\IOAuth2Client;
 use OAuth2\Tests\Fixtures\OAuth2StorageStub;
+use Symfony\Component\HttpFoundation\Response;
 
 class OAuth2GrantExtensionJwtBearer extends OAuth2StorageStub implements IOAuth2GrantExtension
 {
@@ -15,7 +16,7 @@ class OAuth2GrantExtensionJwtBearer extends OAuth2StorageStub implements IOAuth2
     public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders)
     {
         if ('urn:ietf:params:oauth:grant-type:jwt-bearer' !== $uri) {
-            throw new OAuth2ServerException(OAuth2::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
+            throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
         }
 
         if (!isset($inputData['jwt'])) {

--- a/tests/Fixtures/OAuth2GrantExtensionLifetimeStub.php
+++ b/tests/Fixtures/OAuth2GrantExtensionLifetimeStub.php
@@ -6,6 +6,7 @@ use OAuth2\OAuth2;
 use OAuth2\IOAuth2GrantExtension;
 use OAuth2\OAuth2ServerException;
 use OAuth2\Model\IOAuth2Client;
+use Symfony\Component\HttpFoundation\Response;
 
 class OAuth2GrantExtensionLifetimeStub extends OAuth2StorageStub implements IOAuth2GrantExtension
 {
@@ -14,7 +15,7 @@ class OAuth2GrantExtensionLifetimeStub extends OAuth2StorageStub implements IOAu
     public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders)
     {
         if ('http://company.com/fb_access_token_time_limited' !== $uri) {
-            throw new OAuth2ServerException(OAuth2::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
+            throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
         }
 
         if (!isset($inputData['fb_access_token'])) {

--- a/tests/Fixtures/OAuth2GrantExtensionStub.php
+++ b/tests/Fixtures/OAuth2GrantExtensionStub.php
@@ -7,6 +7,7 @@ use OAuth2\IOAuth2GrantExtension;
 use OAuth2\OAuth2ServerException;
 use OAuth2\Model\IOAuth2Client;
 use OAuth2\Tests\Fixtures\OAuth2StorageStub;
+use Symfony\Component\HttpFoundation\Response;
 
 class OAuth2GrantExtensionStub extends OAuth2StorageStub implements IOAuth2GrantExtension
 {
@@ -15,7 +16,7 @@ class OAuth2GrantExtensionStub extends OAuth2StorageStub implements IOAuth2Grant
     public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders)
     {
         if ('http://company.com/fb_access_token' !== $uri) {
-            throw new OAuth2ServerException(OAuth2::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
+            throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);
         }
 
         if (!isset($inputData['fb_access_token'])) {


### PR DESCRIPTION
In **oauth2-php/lib/OAuth2.php**, status code should be changed from
```php
const HTTP_FOUND = '302 Found';
const HTTP_BAD_REQUEST = '400 Bad Request';
const HTTP_UNAUTHORIZED = '401 Unauthorized';
const HTTP_FORBIDDEN = '403 Forbidden';
const HTTP_UNAVAILABLE = '503 Service Unavailable';
```
to
```php
const HTTP_FOUND = Response::HTTP_FOUND;
const HTTP_BAD_REQUEST = Response::HTTP_BAD_REQUEST;
const HTTP_UNAUTHORIZED = Response::HTTP_UNAUTHORIZED;
const HTTP_FORBIDDEN = Response::HTTP_FORBIDDEN;
const HTTP_UNAVAILABLE = Response::HTTP_SERVICE_UNAVAILABLE;
```
The reason for that is that the lib now fails with SF4 with
`Notice: A non well formed numeric value encountered`

This happens here, **oauth2-php/lib/OAuth2ServerException.php**
```php
public function getHttpResponse()
{
    return new Response(
        $this->getResponseBody(),
        $this->getHttpCode(),
        $this->getResponseHeaders()
    );
}
```
And Symfony Response class is expecting this
```php
public function __construct($content = '', int $status = 200, array $headers = array())
{
    $this->headers = new ResponseHeaderBag($headers);
    $this->setContent($content);
    $this->setStatusCode($status);
    $this->setProtocolVersion('1.0');
}
```
`$status` must be a well-formed int.

**EDIT**: I followed @Spomky suggestion and updated the PR.