### PR TITLE
add manual convert string httpCode to int

### DIFF
--- a/lib/OAuth2ServerException.php
+++ b/lib/OAuth2ServerException.php
@@ -68,7 +68,7 @@ class OAuth2ServerException extends \Exception
     {
         return new Response(
             $this->getResponseBody(),
-            $this->getHttpCode(),
+            (int) $this->getHttpCode(),
             $this->getResponseHeaders()
         );
     }


### PR DESCRIPTION
Second argument of `Symfony\Component\HttpFoundation\Response::__construct()` typehinted for `int`