### PR TITLE
Added OAuth2 interface

### DIFF
--- a/lib/IOAuth2.php
+++ b/lib/IOAuth2.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace OAuth2;
+
+use OAuth2\Model\IOAuth2AccessToken;
+use OAuth2\Model\IOAuth2Client;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Originally written by Dmitrii Poddubnyi <dpoddubny@gmail.com>.
+ */
+interface IOAuth2
+{
+    /**
+     * Returns a persistent variable.
+     *
+     * @param string $name The name of the variable to return.
+     * @param mixed $default The default value to use if this variable has never been set.
+     *
+     * @return mixed   The value of the variable.
+     */
+    public function getVariable($name, $default = null);
+
+    /**
+     * Sets a persistent variable.
+     *
+     * @param string $name The name of the variable to set.
+     * @param mixed $value The value to set.
+     *
+     * @return OAuth2 The application (for chained calls of this method)
+     */
+    public function setVariable($name, $value);
+
+    /**
+     * Check that a valid access token has been provided.
+     * The token is returned (as an associative array) if valid.
+     *
+     * The scope parameter defines any required scope that the token must have.
+     * If a scope param is provided and the token does not have the required
+     * scope, we bounce the request.
+     *
+     * Some implementations may choose to return a subset of the protected
+     * resource (i.e. "public" data) if the user has not provided an access
+     * token or if the access token is invalid or expired.
+     *
+     * The IETF spec says that we should send a 401 Unauthorized header and
+     * bail immediately so that's what the defaults are set to. You can catch
+     * the exception thrown and behave differently if you like (log errors, allow
+     * public access for missing tokens, etc)
+     *
+     * @param string $tokenParam
+     * @param string $scope A space-separated string of required scope(s), if you want to check for scope.
+     *
+     * @return IOAuth2AccessToken Token
+     *
+     * @throws OAuth2AuthenticateException
+     * @see     http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-7
+     *
+     * @ingroup oauth2_section_7
+     */
+    public function verifyAccessToken($tokenParam, $scope = null);
+
+    /**
+     * This is a convenience function that can be used to get the token, which can then
+     * be passed to verifyAccessToken(). The constraints specified by the draft are
+     * attempted to be adheared to in this method.
+     *
+     * As per the Bearer spec (draft 8, section 2) - there are three ways for a client
+     * to specify the bearer token, in order of preference: Authorization Header,
+     * POST and GET.
+     *
+     * NB: Resource servers MUST accept tokens via the Authorization scheme
+     * (http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2).
+     *
+     * @param Request $request
+     * @param bool $removeFromRequest
+     *
+     * @return string|null
+     * @throws OAuth2AuthenticateException
+     * @todo Should we enforce TLS/SSL in this function?
+     *
+     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1
+     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2
+     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3
+     *
+     */
+    public function getBearerToken(Request $request = null, $removeFromRequest = false);
+
+    /**
+     * Grant or deny a requested access token.
+     *
+     * This would be called from the "/token" endpoint as defined in the spec.
+     * Obviously, you can call your endpoint whatever you want.
+     * Draft specifies that the authorization parameters should be retrieved from POST, but you can override to whatever method you like.
+     *
+     * @param Request $request (optional) The request
+     *
+     * @return Response
+     * @throws OAuth2ServerException
+     *
+     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4
+     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-10.6
+     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.1.3
+     *
+     * @ingroup  oauth2_section_4
+     */
+    public function grantAccessToken(Request $request = null);
+
+    /**
+     * Redirect the user appropriately after approval.
+     *
+     * After the user has approved or denied the access request the authorization server should call this function to
+     * redirect the user appropriately.
+     *
+     * @param bool $isAuthorized true or false depending on whether the user authorized the access.
+     * @param mixed $data Application data
+     * @param Request $request
+     * @param string|null $scope
+     *
+     * @return Response
+     * @throws OAuth2RedirectException
+     *
+     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4
+     *
+     * @ingroup  oauth2_section_4
+     */
+    public function finishClientAuthorization($isAuthorized, $data = null, Request $request = null, $scope = null);
+
+    /**
+     * Handle the creation of access token, also issue refresh token if support.
+     *
+     * This belongs in a separate factory, but to keep it simple, I'm just keeping it here.
+     *
+     * @param IOAuth2Client $client
+     * @param mixed $data
+     * @param string|null $scope
+     * @param int|null $access_token_lifetime How long the access token should live in seconds
+     * @param bool $issue_refresh_token Issue a refresh tokeniIf true and the storage mechanism supports it
+     * @param int|null $refresh_token_lifetime How long the refresh token should life in seconds
+     *
+     * @return array
+     *
+     * @see     http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-5
+     *
+     * @ingroup oauth2_section_5
+     */
+    public function createAccessToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null);
+}

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -47,7 +47,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @author Debug, coding style clean up and documented by Edison Wong <hswong3i@pantarei-design.com>.
  * @author Refactored (including separating from raw POST/GET) and updated to draft v20 by David Rochwerger <catch.dave@gmail.com>.
  */
-class OAuth2
+class OAuth2 implements IOAuth2
 {
     /**
      * Array of persistent variables stored.
@@ -430,12 +430,7 @@ class OAuth2
     }
 
     /**
-     * Returns a persistent variable.
-     *
-     * @param string $name    The name of the variable to return.
-     * @param mixed  $default The default value to use if this variable has never been set.
-     *
-     * @return mixed   The value of the variable.
+     * {@inheritdoc}
      */
     public function getVariable($name, $default = null)
     {
@@ -445,12 +440,7 @@ class OAuth2
     }
 
     /**
-     * Sets a persistent variable.
-     *
-     * @param  string $name  The name of the variable to set.
-     * @param  mixed  $value The value to set.
-     *
-     * @return OAuth2 The application (for chained calls of this method)
+     * {@inheritdoc}
      */
     public function setVariable($name, $value)
     {
@@ -464,31 +454,7 @@ class OAuth2
     // Resource protecting (Section 5).
 
     /**
-     * Check that a valid access token has been provided.
-     * The token is returned (as an associative array) if valid.
-     *
-     * The scope parameter defines any required scope that the token must have.
-     * If a scope param is provided and the token does not have the required
-     * scope, we bounce the request.
-     *
-     * Some implementations may choose to return a subset of the protected
-     * resource (i.e. "public" data) if the user has not provided an access
-     * token or if the access token is invalid or expired.
-     *
-     * The IETF spec says that we should send a 401 Unauthorized header and
-     * bail immediately so that's what the defaults are set to. You can catch
-     * the exception thrown and behave differently if you like (log errors, allow
-     * public access for missing tokens, etc)
-     *
-     * @param string $tokenParam
-     * @param string $scope A space-separated string of required scope(s), if you want to check for scope.
-     *
-     * @throws OAuth2AuthenticateException
-     * @return IOAuth2AccessToken Token
-     *
-     * @see     http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-7
-     *
-     * @ingroup oauth2_section_7
+     * {@inheritdoc}
      */
     public function verifyAccessToken($tokenParam, $scope = null)
     {
@@ -520,28 +486,7 @@ class OAuth2
     }
 
     /**
-     * This is a convenience function that can be used to get the token, which can then
-     * be passed to verifyAccessToken(). The constraints specified by the draft are
-     * attempted to be adheared to in this method.
-     *
-     * As per the Bearer spec (draft 8, section 2) - there are three ways for a client
-     * to specify the bearer token, in order of preference: Authorization Header,
-     * POST and GET.
-     *
-     * NB: Resource servers MUST accept tokens via the Authorization scheme
-     * (http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2).
-     *
-     * @todo Should we enforce TLS/SSL in this function?
-     *
-     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1
-     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2
-     * @see  http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3
-     *
-     * @param Request $request
-     * @param bool    $removeFromRequest
-     *
-     * @return string|null
-     * @throws OAuth2AuthenticateException
+     * {@inheritdoc}
      */
     public function getBearerToken(Request $request = null, $removeFromRequest = false)
     {
@@ -734,22 +679,7 @@ class OAuth2
     // Access token granting (Section 4).
 
     /**
-     * Grant or deny a requested access token.
-     *
-     * This would be called from the "/token" endpoint as defined in the spec.
-     * Obviously, you can call your endpoint whatever you want.
-     * Draft specifies that the authorization parameters should be retrieved from POST, but you can override to whatever method you like.
-     *
-     * @param  Request $request (optional) The request
-     *
-     * @return Response
-     * @throws OAuth2ServerException
-     *
-     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4
-     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-10.6
-     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-21#section-4.1.3
-     *
-     * @ingroup  oauth2_section_4
+     * {@inheritdoc}
      */
     public function grantAccessToken(Request $request = null)
     {
@@ -1194,22 +1124,7 @@ class OAuth2
     }
 
     /**
-     * Redirect the user appropriately after approval.
-     *
-     * After the user has approved or denied the access request the authorization server should call this function to
-     * redirect the user appropriately.
-     *
-     * @param bool        $isAuthorized true or false depending on whether the user authorized the access.
-     * @param mixed       $data         Application data
-     * @param Request     $request
-     * @param string|null $scope
-     *
-     * @throws OAuth2RedirectException
-     *
-     * @return Response
-     * @see      http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4
-     *
-     * @ingroup  oauth2_section_4
+     * {@inheritdoc}
      */
     public function finishClientAuthorization($isAuthorized, $data = null, Request $request = null, $scope = null)
     {
@@ -1314,22 +1229,7 @@ class OAuth2
     }
 
     /**
-     * Handle the creation of access token, also issue refresh token if support.
-     *
-     * This belongs in a separate factory, but to keep it simple, I'm just keeping it here.
-     *
-     * @param IOAuth2Client $client
-     * @param mixed         $data
-     * @param string|null   $scope
-     * @param int|null      $access_token_lifetime How long the access token should live in seconds
-     * @param bool          $issue_refresh_token Issue a refresh tokeniIf true and the storage mechanism supports it
-     * @param int|null      $refresh_token_lifetime How long the refresh token should life in seconds
-     *
-     * @return array
-     *
-     * @see     http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-5
-     *
-     * @ingroup oauth2_section_5
+     * {@inheritdoc}
      */
     public function createAccessToken(IOAuth2Client $client, $data, $scope = null, $access_token_lifetime = null, $issue_refresh_token = true, $refresh_token_lifetime = null)
     {


### PR DESCRIPTION
Hello,
We all know that decoration is always preferred over inheritance. The class OAuth2 doesn't have an interface so it's not possible to decorate, and all its users are forced to hard-code its class, e.g AuthorizeController [requires OAuth2\OAuth2 in constructor](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/blob/1.6.2/Controller/AuthorizeController.php#L108), although it should require an interface, so the OAuth2 class can be easily decorated.

This PR extracts an interface from OAuth2 class. Once it merged I'm going to make changes to FOSOAuthServerBundle so that it doesn't depend on OAuth class directly.