### PR TITLE
Fix implicit redirect parameters and validation

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -728,7 +728,10 @@ class OAuth2 implements IOAuth2
             throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, self::ERROR_INVALID_CLIENT, 'The client credentials are invalid');
         }
 
-        if ($this->storage->checkClientCredentials($client, $clientCredentials[1]) === false) {
+        // if grant type is auth code, client is validated in grantAccessTokenAuthCode()
+        if ($input['grant_type'] !== self::GRANT_TYPE_AUTH_CODE
+            && $this->storage->checkClientCredentials($client, $clientCredentials[1]) === false
+        ) {
             throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, self::ERROR_INVALID_CLIENT, 'The client credentials are invalid');
         }
 
@@ -1159,6 +1162,9 @@ class OAuth2 implements IOAuth2
         } else {
             if ($params["response_type"] === self::RESPONSE_TYPE_AUTH_CODE) {
                 $result[self::TRANSPORT_QUERY]['state'] = $params["state"];
+                $result[self::TRANSPORT_QUERY]["grant_type"] = self::GRANT_TYPE_AUTH_CODE;
+                $result[self::TRANSPORT_QUERY]["redirect_uri"] = $params["redirect_uri"];
+                $result[self::TRANSPORT_QUERY]["client_id"] = $params["client_id"];
                 $result[self::TRANSPORT_QUERY]["code"] = $this->createAuthCode(
                     $params["client"],
                     $data,

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -729,7 +729,9 @@ class OAuth2 implements IOAuth2
         }
 
         // if grant type is auth code, client is validated in grantAccessTokenAuthCode()
+        // and if grant type is refresh token, client secret is superfluous
         if ($input['grant_type'] !== self::GRANT_TYPE_AUTH_CODE
+            && $input['grant_type'] !== self::GRANT_TYPE_REFRESH_TOKEN
             && $this->storage->checkClientCredentials($client, $clientCredentials[1]) === false
         ) {
             throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, self::ERROR_INVALID_CLIENT, 'The client credentials are invalid');

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -571,7 +571,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
         $stub->setAllowedGrantTypes(array('authorization_code', 'password'));
 
         $oauth2 = new OAuth2($stub);
-        
+
         try {
             $oauth2->grantAccessToken(new Request(array(
                 'grant_type' => 'password',
@@ -756,7 +756,7 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
         )));
 
         $this->assertSame(302, $response->getStatusCode());
-        $this->assertRegExp('#^http://www\.example\.com/\?foo=bar&state=42&code=#', $response->headers->get('location'));
+        $this->assertRegExp('#^http://www\.example\.com/\?foo=bar&state=42&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fwww.example.com%2F%3Ffoo%3Dbar&client_id=blah&code=#', $response->headers->get('location'));
 
         $code = $stub->getLastAuthCode();
         $this->assertSame('blah', $code->getClientId());


### PR DESCRIPTION
1) During an implicit authentication, the redirect URI callback response is missing required parameters.  This fix adds the `grant_type` of the defined constant, and `redirect_uri` and `client_id` from the request.

2) After the redirect, the client is always validated against the client secret, which is not present in the callback parameters, nor necessary.  This fix ignores the `client_secret` validation for implicit authentication, allowing the validation to proceed against the `code` argument.