### PR TITLE
[Security] Add exact check for domain and port

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -1433,7 +1433,8 @@ class OAuth2 implements IOAuth2
 
         foreach ($storedUris as $storedUri) {
             if (strcasecmp(substr($inputUri, 0, strlen($storedUri)), $storedUri) === 0) {
-                return true;
+                return parse_url($inputUri, PHP_URL_HOST) === parse_url($storedUri, PHP_URL_HOST) &&
+                    parse_url($inputUri, PHP_URL_PORT) === parse_url($storedUri, PHP_URL_PORT);
             }
         }
 

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -892,6 +892,50 @@ class OAuth2Test extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFinishClientAuthorizationThrowsErrorIfNoMatchingDomain()
+    {
+        $stub = new OAuth2GrantCodeStub;
+        $stub->addClient(new OAuth2Client('blah', 'foo', array('http://a.example.com')));
+        $oauth2 = new OAuth2($stub);
+
+        $data = new \stdClass;
+
+        try {
+            $oauth2->finishClientAuthorization(true, $data, new Request(array(
+                'client_id' => 'blah',
+                'response_type' => 'code',
+                'state' => '42',
+                'redirect_uri' => 'http://a.example.com.test.com/',
+            )));
+            $this->fail('The expected exception OAuth2ServerException was not thrown');
+        } catch (OAuth2ServerException $e) {
+            $this->assertSame('redirect_uri_mismatch', $e->getMessage());
+            $this->assertSame('The redirect URI provided does not match registered URI(s).', $e->getDescription());
+        }
+    }
+
+    public function testFinishClientAuthorizationThrowsErrorIfNoMatchingPort()
+    {
+        $stub = new OAuth2GrantCodeStub;
+        $stub->addClient(new OAuth2Client('blah', 'foo', array('http://a.example.com:80')));
+        $oauth2 = new OAuth2($stub);
+
+        $data = new \stdClass;
+
+        try {
+            $oauth2->finishClientAuthorization(true, $data, new Request(array(
+                'client_id' => 'blah',
+                'response_type' => 'code',
+                'state' => '42',
+                'redirect_uri' => 'http://a.example.com:8080/',
+            )));
+            $this->fail('The expected exception OAuth2ServerException was not thrown');
+        } catch (OAuth2ServerException $e) {
+            $this->assertSame('redirect_uri_mismatch', $e->getMessage());
+            $this->assertSame('The redirect URI provided does not match registered URI(s).', $e->getDescription());
+        }
+    }
+
     public function testFinishClientAuthorizationThrowsErrorIfRedirectUriAttemptsPathTraversal()
     {
         $stub = new OAuth2GrantCodeStub;


### PR DESCRIPTION
There is security bug in URI checking code. If there is no path for URI it is possible to bypass check. Code only check if start of URI, so for `http://a.example.com` it is possible to bypass check using `http://a.example.com.test.com/`.