### PR TITLE
Update OAuth2.php

### DIFF
--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -1433,8 +1433,11 @@ class OAuth2 implements IOAuth2
 
         foreach ($storedUris as $storedUri) {
             if (strcasecmp(substr($inputUri, 0, strlen($storedUri)), $storedUri) === 0) {
-                return parse_url($inputUri, PHP_URL_HOST) === parse_url($storedUri, PHP_URL_HOST) &&
-                    parse_url($inputUri, PHP_URL_PORT) === parse_url($storedUri, PHP_URL_PORT);
+                if (parse_url($inputUri, PHP_URL_HOST) === parse_url($storedUri, PHP_URL_HOST) 
+                    && parse_url($inputUri, PHP_URL_PORT) === parse_url($storedUri, PHP_URL_PORT)
+                ) {
+                    return true;   
+                }
             }
         }
 


### PR DESCRIPTION
If $storedUris contains multiple entries of the same domain with different ports, this check was returning (true or false) on the first uri and not validating all of the values in the array.